### PR TITLE
Add javax.activation dependency to support Java>8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>javax.activation</groupId>
+			<artifactId>activation</artifactId>
+			<version>1.1.1</version>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
javax.activation was removed from Java>8